### PR TITLE
Don't assume octet-stream

### DIFF
--- a/ReactNativeGit/patch-FileReader.js
+++ b/ReactNativeGit/patch-FileReader.js
@@ -8,9 +8,7 @@ FileReader.prototype.readAsArrayBuffer = function(blob) {
   this._error = null;
   const fr = new FileReader();
   fr.onloadend = () => {
-    const content = atob(
-      fr.result.substr('data:application/octet-stream;base64,'.length),
-    );
+    const content = atob(fr.result.replace(/data:[^;]+;base64,/, ""));
     const buffer = new ArrayBuffer(content.length);
     const view = new Uint8Array(buffer);
     view.set(Array.from(content).map(c => c.charCodeAt(0)));


### PR DESCRIPTION
The example didn't work for me on iOS. The type was not octet-stream but plain text.